### PR TITLE
Specialize ComputationalResult for internal use?

### DIFF
--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/ComputationalResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/ComputationalResult.java
@@ -25,7 +25,7 @@ public class ComputationalResult {
      * @param resultIsLogicallyTrue Indicates if the result of the computation
      * is logically consistent with what the operation asks.
      */
-    public ComputationalResult(final boolean resultIsLogicallyTrue) {
+    public ComputationalResult(boolean resultIsLogicallyTrue) {
         this.message = "";
         this.resultIsLogicallyTrue = resultIsLogicallyTrue;
     }
@@ -37,7 +37,7 @@ public class ComputationalResult {
      * is logically consistent with what the operation asks.
      * @param message The computed result itself or a description
      */
-    public ComputationalResult(final boolean resultIsLogicallyTrue, final String message) {
+    public ComputationalResult(boolean resultIsLogicallyTrue, @NonNull final String message) {
         this.message = message;
         this.resultIsLogicallyTrue = resultIsLogicallyTrue;
     }

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/ComputationalResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/ComputationalResult.java
@@ -12,7 +12,7 @@ import lombok.NonNull;
  */
 @Data
 @JsonInclude(Include.NON_NULL)
-public final class ComputationalResult {
+public class ComputationalResult {
 
     @NonNull
     private final String message;

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
@@ -33,7 +33,10 @@ public class PrimeFactorizationResult extends ComputationalResult {
      * @return tally of prime factors
      */
     public HashMap<Integer, Integer> getFactors() {
+        // holds a tally of each prime factor
         HashMap<Integer, Integer> factors = new HashMap<>();
+        
+        // getMessage() is in the form:     number = factor \u22C5 factor ...
         String stringFactors = getMessage().split("=")[1].trim();
         stringFactors = stringFactors.replace("\u22C5", "");
         stringFactors = stringFactors.replace(" ", "");

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
@@ -1,18 +1,53 @@
 package ca.vapurrmaid.discretemathapplications.domain.computation;
 
 import java.util.HashMap;
-import java.util.Map;
+import lombok.NonNull;
 
 /**
+ * Specialization of {@link ComputationalResult} for factorization
+ *
  * @author vapurrmaid
  */
 public class PrimeFactorizationResult extends ComputationalResult {
 
-    private final Map<Integer, Integer> primeFactors;
+    // disallow empty constructor
+    private PrimeFactorizationResult() {
+        super(false, "");
+    }
 
-    public PrimeFactorizationResult(boolean resultIsLogicallyTrue, String message) {
+    /**
+     * Constructor.
+     *
+     * @param resultIsLogicallyTrue Indicates if the result of the computation
+     * is logically consistent with what the operation asks.
+     * @param message The computed result itself or a description
+     */
+    public PrimeFactorizationResult(boolean resultIsLogicallyTrue, @NonNull String message) {
         super(resultIsLogicallyTrue, message);
-        primeFactors = new HashMap<>();
+    }
+
+    /**
+     * Returns a tally, in a <code>HashMap<Integer, Integer></code> of each
+     * prime factor
+     *
+     * @return tally of prime factors
+     */
+    public HashMap<Integer, Integer> getFactors() {
+        HashMap<Integer, Integer> factors = new HashMap<>();
+        String stringFactors = getMessage().split("=")[1].trim();
+        stringFactors = stringFactors.replace("\u22C5", "");
+        stringFactors = stringFactors.replace(" ", "");
+
+        for (int i = 0; i < stringFactors.length(); i++) {
+            Integer key = Integer.valueOf(String.valueOf(stringFactors.charAt(i)));
+            if (factors.containsKey(key)) {
+                factors.put(key, factors.get(key) + 1);
+            } else {
+                factors.put(key, 1);
+            }
+        }
+
+        return factors;
     }
 
 }

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
@@ -27,8 +27,8 @@ public class PrimeFactorizationResult extends ComputationalResult {
     }
 
     /**
-     * Returns a tally, in a <code>HashMap<Integer, Integer></code> of each
-     * prime factor
+     * Returns a tally, in the form of a <code>HashMap<Integer, Integer></code>,
+     * of each prime factor.
      *
      * @return tally of prime factors
      */

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
@@ -1,0 +1,18 @@
+package ca.vapurrmaid.discretemathapplications.domain.computation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author vapurrmaid
+ */
+public class PrimeFactorizationResult extends ComputationalResult {
+
+    private final Map<Integer, Integer> primeFactors;
+
+    public PrimeFactorizationResult(boolean resultIsLogicallyTrue, String message) {
+        super(resultIsLogicallyTrue, message);
+        primeFactors = new HashMap<>();
+    }
+
+}

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImpl.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImpl.java
@@ -4,6 +4,7 @@ import ca.vapurrmaid.discretemathapplications.domain.computation.Computation;
 import ca.vapurrmaid.discretemathapplications.domain.computation.ComputationalResult;
 import ca.vapurrmaid.discretemathapplications.domain.computation.ComputationalStep;
 import ca.vapurrmaid.discretemathapplications.domain.NaturalNumber;
+import ca.vapurrmaid.discretemathapplications.domain.computation.PrimeFactorizationResult;
 import ca.vapurrmaid.discretemathapplications.error.NaturalNumberException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -88,7 +89,7 @@ public class PrimeServiceImpl implements PrimeService {
         int original = n.getNumberAsInteger();
 
         if (n.getNumberAsInteger() == 1) {
-            computation.setResult(new ComputationalResult(true, "1"));
+            computation.setResult(new PrimeFactorizationResult(true, "1 = 1"));
             return computation;
         }
 
@@ -120,7 +121,7 @@ public class PrimeServiceImpl implements PrimeService {
         factorization += n.getNumberAsInteger();
         computation.appendComputationalStep(new ComputationalStep("remainder is prime, stop", ""));
 
-        computation.setResult(new ComputationalResult(true, String.format("%d = %s", original, factorization)));
+        computation.setResult(new PrimeFactorizationResult(true, String.format("%d = %s", original, factorization)));
         return computation;
     }
 

--- a/src/test/java/ca/vapurrmaid/discretemathapplications/domain/Computation/PrimeFactorizationResultTest.java
+++ b/src/test/java/ca/vapurrmaid/discretemathapplications/domain/Computation/PrimeFactorizationResultTest.java
@@ -1,0 +1,40 @@
+package ca.vapurrmaid.discretemathapplications.domain.Computation;
+
+import ca.vapurrmaid.discretemathapplications.domain.computation.PrimeFactorizationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class PrimeFactorizationResultTest {
+
+    PrimeFactorizationResult one;
+    PrimeFactorizationResult ten;
+    PrimeFactorizationResult twenty;
+
+    @Before
+    public void setup() {
+        one = new PrimeFactorizationResult(true, "1 = 1");
+        ten = new PrimeFactorizationResult(true, "10 = 2 \u22C5 5");
+        twenty = new PrimeFactorizationResult(true, "20 = 2 \u22C5 2 \u22C5 5");
+    }
+
+    @Test
+    public void testGetFactors() {
+        assertThat(one.getFactors())
+                .containsExactly(
+                        entry(1, 1));
+
+        assertThat(ten.getFactors())
+                .containsExactly(
+                        entry(2, 1),
+                        entry(5, 1));
+
+        assertThat(twenty.getFactors())
+                .containsExactly(
+                        entry(2, 2),
+                        entry(5, 1));
+    }
+
+}

--- a/src/test/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImplTest.java
+++ b/src/test/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImplTest.java
@@ -57,7 +57,7 @@ public class PrimeServiceImplTest {
     @Test
     public void testPrimeFactorsOfNaturalNumber() throws NaturalNumberException {
         // test edge case - 1
-        assertThat(primeService.primeFactorsOfNaturalNumber(new NaturalNumber(1)).getResult().getMessage()).isEqualTo("1");
+        assertThat(primeService.primeFactorsOfNaturalNumber(new NaturalNumber(1)).getResult().getMessage()).isEqualTo("1 = 1");
 
         // test 2, 3, 5 and multiples
         assertThat(primeService.primeFactorsOfNaturalNumber(new NaturalNumber(6)).getResult().getMessage()).isEqualTo("6 = 2\u22c53");


### PR DESCRIPTION
## Proposed Changes
- Use specializations of `ComputationalResult` containing specialized data that can optionally be sent to clients
  - Can use across internal services
