### PR TITLE
HashMap -> TreeMap to preserve Key Order

### DIFF
--- a/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/domain/computation/PrimeFactorizationResult.java
@@ -1,9 +1,9 @@
 package ca.vapurrmaid.discretemathapplications.domain.computation;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +18,13 @@ import lombok.ToString;
 public class PrimeFactorizationResult implements ComputationalResult {
 
     /**
-     * Returns a tally, in the form of <code>HashMap<Integer, Integer></code>,
+     * Returns a tally, in the form of <code>TreeMap<Integer, Integer></code>,
      * of each prime factor.
      *
      * @return prime tally
      */
     @Getter
-    private final Map<Integer, Integer> factors = new HashMap<>();
+    private final Map<Integer, Integer> factors = new TreeMap<>();
 
     @Getter
     private final int number;

--- a/src/main/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImpl.java
+++ b/src/main/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImpl.java
@@ -89,7 +89,7 @@ public class PrimeServiceImpl implements PrimeService {
         int original = n.getNumberAsInteger();
         PrimeFactorizationResult factorization = new PrimeFactorizationResult(original);
 
-        if (n.getNumberAsInteger() == 1) {
+        if (original == 1) {
             factorization.addPrimeFactor(1);
             computation.setResult(factorization);
             return computation;

--- a/src/test/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImplTest.java
+++ b/src/test/java/ca/vapurrmaid/discretemathapplications/services/PrimeServiceImplTest.java
@@ -70,7 +70,12 @@ public class PrimeServiceImplTest {
         // advanced case - 3 different factors, one repeating, one with multiple digits
         res = primeService.primeFactorsOfNaturalNumber(new NaturalNumber(220)).getResult();
         assertThat(res.getResultIsLogicallyTrue()).isTrue();
-        assertThat(res.getMessage()).isEqualTo("\u2234 220 = 2\u22c52\u22c55\u22c511");
+        assertThat(res.getMessage()).isEqualTo("\u2234 220 = 2\u22c52\u22C55\u22C511");
+
+        // Issue #7 https://github.com/discomath/discomathserver/issues/7 - Test Message Ordering
+        res = primeService.primeFactorsOfNaturalNumber(new NaturalNumber(1589)).getResult();
+        assertThat(res.getResultIsLogicallyTrue()).isTrue();
+        assertThat(res.getMessage()).isEqualTo("\u2234 1589 = 7\u22C5227");
 
         // test primes yield themselves
         for (int p : first100Primes) {


### PR DESCRIPTION
* https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html

Fixes #7 

Proposed Changes
- Added Test Case
- Changed `HashMap` to `TreeMap` in `PrimeFactorizationResult`
